### PR TITLE
Use BB Promise

### DIFF
--- a/js/template.js
+++ b/js/template.js
@@ -1,5 +1,7 @@
 /* global TrelloPowerUp */
 
+var Promise = TrelloPowerUp.Promise;
+
 var getIdBadge = function(t){
   return Promise.all([
     t.get('board', 'shared', 'prefix', '#'),


### PR DESCRIPTION
We had a few users report that the Power-Up wasn't working as expected on a few browsers. Come to find out, the browsers were ones that don't have native support for `Promise` yet.