### PR TITLE
Remove New JS Syntax

### DIFF
--- a/js/template.js
+++ b/js/template.js
@@ -1,5 +1,7 @@
 /* global TrelloPowerUp */
 
+var Promise = TrelloPowerUp.Promise;
+
 var getIdBadge = function(t){
   return Promise.all([
     t.get('board', 'shared', 'prefix', '#'),

--- a/js/template.js
+++ b/js/template.js
@@ -7,10 +7,10 @@ var getIdBadge = function(t){
     t.get('board', 'shared', 'prefix', '#'),
     t.card('idShort').get('idShort')
   ])
-  .then(function([prefix, idShort]){
+  .then(function(result){
     return [{
       title: 'Card Number', // for detail badges only
-      text: prefix + idShort
+      text: result[0] + result[1]
     }];
   })
 };


### PR DESCRIPTION
I missed this in my [previous PR](https://github.com/reenhanced/trello-card-numbers/pull/2) but older browsers don't support the function parameter syntax.